### PR TITLE
Update package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,12 +16,12 @@ ByteCompile: true
 Imports: 
     knitr,
     rmarkdown,
-    automagic,
+    checkpoint,
     htmltools,
     htmlwidgets,
     snakecase,
     yaml,
-    usethis (>= 1.3.0.9000),
+    usethis (>= 1.4.0),
     stringr,
     glue,
     jsonlite,
@@ -34,5 +34,3 @@ License: MIT + file LICENSE
 Suggests: 
     testthat,
     covr
-Remotes:
-    r-lib/usethis

--- a/R/get_and_update_dependencies.R
+++ b/R/get_and_update_dependencies.R
@@ -8,6 +8,6 @@
 #' @return Used for pure side effect
 #' @export
 get_and_update_dependencies <- function(dir = "content/post/") {
-  automagic::make_deps_file(dir)
-  automagic::automagic(dir)
+  pkgs <- checkpoint::scanForPackages("content/post", use.knitr = TRUE)$pkgs
+  install.packages(pkgs)
 }

--- a/R/render_new_rmds_to_md.R
+++ b/R/render_new_rmds_to_md.R
@@ -13,7 +13,7 @@
 #' @export
 render_new_rmds_to_md <- function(dir = "content/post", 
                                   build = "new",
-                                  tol = 
+                                  tol = 1,
                                   dry_run = FALSE) {
   match.arg(build, c("all", "old and new", "old", "new"))
   content = dir
@@ -32,7 +32,7 @@ render_new_rmds_to_md <- function(dir = "content/post",
   # Rmd with a too old md
   dplyr::left_join(rmds, mds, by = "slug",
                    suffix = c("_rmd", "_md")) %>%
-    dplyr::filter(.data$change_time_md < .data$change_time_rmd) %>%
+    dplyr::filter((.data$change_time_rmd - .data$change_time_md) > tol) %>%
     dplyr::pull(.data$path_rmd) -> too_old
     
   if(build == "all"){

--- a/R/render_new_rmds_to_md.R
+++ b/R/render_new_rmds_to_md.R
@@ -17,7 +17,8 @@ render_new_rmds_to_md <- function(dir = "content/post",
                                   tol = 1,
                                   dry_run = FALSE) {
   match.arg(build, c("all", "old and new", "old", "new"))
-  content = dir
+  root    <- rprojroot::has_file("DESCRIPTION")
+  content <- root$find_file(dir)
   
   # get info about all files
   info <- fs::dir_info(content)

--- a/R/render_new_rmds_to_md.R
+++ b/R/render_new_rmds_to_md.R
@@ -7,6 +7,7 @@
 #'
 #' @param dir Directory to search for new Rmds in. Defaults to the blog post location of Hugo.
 #' @param build Selection criteria for which Rmds to convert to md, options are c("all", "old and new", "old", "new")
+#' @param when `build = "old"` or `build = "old and new"`, this number will avoid re-building md files that are fewer than `tol` seconds old. 
 #' @param dry_run When `TRUE`, targets are printed, but not rendered. Defaults to `FALSE`.
 #'
 #' @return Used for pure side effect. If `dry_run = TRUE`, then the list of targets to be rendered will be printed.

--- a/R/save_and_use_widget.R
+++ b/R/save_and_use_widget.R
@@ -11,11 +11,11 @@
 #' @return HTML code for iframe of htmlwidget
 #' @export
 save_and_use_widget <- function(x, filename) {
-  dir.create("widgets", showWarnings = FALSE)
-  origwd <- getwd()
-  setwd("widgets")
-  htmlwidgets::saveWidget(x, filename, selfcontained = TRUE)
-  setwd(origwd)
+  root     <- rprojroot::has_file("DESCRIPTION")
+  the_dir  <- root$find_file("static", "post", "widgets")
+  the_file <- root$find_file("static", "post", "widgets", filename)
+  dir.create(the_dir, showWarnings = FALSE)
+  htmlwidgets::saveWidget(x, the_file, selfcontained = TRUE)
   htmltools::tags$iframe(src = file.path("widgets", filename),
                          width = "100%",
                          height = "500px")

--- a/content/post/tutorial-post-creation.Rmd
+++ b/content/post/tutorial-post-creation.Rmd
@@ -33,7 +33,7 @@ If you're new to git and GitHub [check out this nifty guide](http://happygitwith
 
 The general workflow would include the following steps:
 
-1.  **Fork the project** from the GitHub *RECON learn* project:
+1.  [**Fork the project**](https://github.com/reconhub/learn/fork) from the GitHub *RECON learn* project:
 
 This will create a copy of the project in your own GitHub account. You will need to clone this archive, and make the modifications there. You `git clone` would look like:
 
@@ -56,22 +56,22 @@ If your GitHub user name is `johnsnow`.
 
 ## Creating posts <a name="post-creation"></a>
 
-Practicals, tutorials, case studies are contributed as [R Markdown](http://rmarkdown.rstudio.com/) (`.Rmd`) documents and generated markdown ready for conversion as `.md` documents. They are stored in `content/post`. The best way to create a new document is to use the `create_post` function. For instance, this post was created using:
+Practicals, tutorials, case studies are contributed as [R Markdown](http://rmarkdown.rstudio.com/) (`.Rmd`) documents and generated markdown ready for conversion as `.md` documents. They are stored in `content/post`. The best way to create a new document is to use the `create_post()` function. For instance, this post was created using:
 
- ```r
+```{r eval = FALSE}
 learn::create_post(title = "How to create a new post for the site",
                    slug = "post-creation",
                    category = "tutorials",
                    author = "Locke Data")
 ```
 
-See `?create_post` to see further parameters. `create_post` creates and opens the Rmd file, creates a default .bib and a blank place-holder image that you can replace with your own header image.
+See `?create_post()` to see further parameters. `create_post()` creates and opens the Rmd file, creates a default .bib and a blank place-holder image that you can replace with your own header image.
 
 ### Conventions
 
 File-naming conventions are as follows:
 
--   start with `practical` for practicals, `study` for case studies (handled by `create_post`)
+-   start with `practical` for practicals, `study` for case studies (handled by `create_post()`)
 -   use an informative slug.
     -   use lower case, no special characters
     -   be hypen-separated ("-")
@@ -86,7 +86,7 @@ For instance, for a practical using a SEIR model for influenza data:
 
 The YAML header is the beginning of the `Rmd` document, within the `---`. For instance:
 
-``` r
+```{r eval = FALSE}
 ---
 title: Phylogenetic tree reconstruction
 author: Thibaut Jombart
@@ -110,11 +110,9 @@ Fields are mostly self-explanatory, and can be adapted to your needs. The date s
 
 ### Referencing packages
 
-You can load packages or use functions via the typical methods `library(tidyverse)`, `require(magrittr)`, `dplyr::mutate()` and folks can run `learn::get_and_update_dependencies()` file to get all packages mentioned in the `content/posts` directory.
+You can load packages or use functions via the typical methods `library("tidyverse")`, `require("magrittr")`, `dplyr::mutate()` and folks can run `learn::get_and_update_dependencies()` file to get all packages mentioned in the `content/posts` directory.
 
 This means you do not need to have mandatory install statements - you can make these `eval=FALSE`.
-
-NB. The `automagic` package used to get dependencies currently does not like `library("tidyverse")` so remove those speechmarks when writing your post!
 
 ### Storing images
 
@@ -165,6 +163,8 @@ Once a pull request (PR) has been made against [https://github.com/reconhub/lear
 - Locke Data: initial version
 
 - Thibaut Jombart: precisions on cloning and PR deploys
+
+- Zhian N. Kamvar: Clarificaton of rendering and forking
 
 Contributions are welcome via [pull requests](https://github.com/reconhub/learn/pulls).
 

--- a/content/post/tutorial-post-creation.md
+++ b/content/post/tutorial-post-creation.md
@@ -15,18 +15,22 @@ output:
     preserve_yaml: true
 ---
 
-In this article we explain how to contribute new posts and slidedecks for the website.
+In this article we explain how to contribute new posts and slidedecks
+for the website.
 
-General workflow for contributing
----------------------------------
+## General workflow for contributing
 
-If you're new to git and GitHub [check out this nifty guide](http://happygitwithr.com/).
+If you’re new to git and GitHub [check out this nifty
+guide](http://happygitwithr.com/).
 
 The general workflow would include the following steps:
 
-1.  **Fork the project** from the GitHub *RECON learn* project:
+1.  [**Fork the project**](https://github.com/reconhub/learn/fork) from
+    the GitHub *RECON learn* project:
 
-This will create a copy of the project in your own GitHub account. You will need to clone this archive, and make the modifications there. You `git clone` would look like:
+This will create a copy of the project in your own GitHub account. You
+will need to clone this archive, and make the modifications there. You
+`git clone` would look like:
 
 ``` bash
 git clone https://johnsnow@github.com/johnsnow/learn
@@ -36,41 +40,65 @@ If your GitHub user name is `johnsnow`.
 
 1.  Open the project in Rstudio and run `devtools::install()`
 
-2.  **Add new content**, typically in the form of a new `.Rmd` file and associated media (most often images). See more details [in the following section for posts](#post-creation) or in the [section about slidedecks](#slidedeck-creation).
+2.  **Add new content**, typically in the form of a new `.Rmd` file and
+    associated media (most often images). See more details [in the
+    following section for posts](#post-creation) or in the [section
+    about slidedecks](#slidedeck-creation).
 
-3.  **Generate content** by knitting your new Rmd via RStudio's knit button or by running `learn::render_new_rmds_to_md()` to build the `.md` files and associated graphics.
+3.  **Generate content** by knitting your new Rmd via RStudio’s knit
+    button or by running `learn::render_new_rmds_to_md()` to build the
+    `.md` files and associated graphics.
 
-4.  `git commit` and `git push` all changes; don't forget to add new images as well (run `git status` to see which files haven't been added).
+4.  `git commit` and `git push` all changes; don’t forget to add new
+    images as well (run `git status` to see which files haven’t been
+    added).
 
-5.  Make a **pull request** against the main project (`master` branch), from the GitHub *RECON learn* project. Make sure you use `reconhub/learn`, branch `master` as base fork. Every pull request will trigger a new deploy of the website, so that new versions can be visualised online (see section *Visualising the changes* below)
+5.  Make a **pull request** against the main project (`master` branch),
+    from the GitHub *RECON learn* project. Make sure you use
+    `reconhub/learn`, branch `master` as base fork. Every pull request
+    will trigger a new deploy of the website, so that new versions can
+    be visualised online (see section *Visualising the changes* below)
 
-Creating posts <a name="post-creation"></a>
--------------------------------------------
+## Creating posts <a name="post-creation"></a>
 
-Practicals, tutorials, case studies are contributed as [R Markdown](http://rmarkdown.rstudio.com/) (`.Rmd`) documents and generated markdown ready for conversion as `.md` documents. They are stored in `content/post`. The best way to create a new document is to use the `create_post` function. For instance, this post was created using:
+Practicals, tutorials, case studies are contributed as [R
+Markdown](http://rmarkdown.rstudio.com/) (`.Rmd`) documents and
+generated markdown ready for conversion as `.md` documents. They are
+stored in `content/post`. The best way to create a new document is to
+use the `create_post()` function. For instance, this post was created
+using:
 
-`r learn::create_post(title = "How to create a new post for the site",                    slug = "post-creation",                    category = "tutorials",                    author = "Locke Data")`
+``` r
+learn::create_post(title = "How to create a new post for the site",
+                   slug = "post-creation",
+                   category = "tutorials",
+                   author = "Locke Data")
+```
 
-See `?create_post` to see further parameters. `create_post` creates and opens the Rmd file, creates a default .bib and a blank place-holder image that you can replace with your own header image.
+See `?create_post()` to see further parameters. `create_post()` creates
+and opens the Rmd file, creates a default .bib and a blank place-holder
+image that you can replace with your own header image.
 
 ### Conventions
 
 File-naming conventions are as follows:
 
--   start with `practical` for practicals, `study` for case studies (handled by `create_post`)
--   use an informative slug.
-    -   use lower case, no special characters
-    -   be hypen-separated ("-")
+  - start with `practical` for practicals, `study` for case studies
+    (handled by `create_post()`)
+  - use an informative slug.
+      - use lower case, no special characters
+      - be hypen-separated (“-”)
 
 For instance, for a practical using a SEIR model for influenza data:
 
--   `seir-influenza` is a good slug
--   `SEIR-flu` is bad because it has capitalised letters
--   `new` is bad, as it is non-informative
+  - `seir-influenza` is a good slug
+  - `SEIR-flu` is bad because it has capitalised letters
+  - `new` is bad, as it is non-informative
 
 ### Editing the YAML header
 
-The YAML header is the beginning of the `Rmd` document, within the `---`. For instance:
+The YAML header is the beginning of the `Rmd` document, within the
+`---`. For instance:
 
 ``` r
 ---
@@ -92,29 +120,45 @@ output:
 ---
 ```
 
-Fields are mostly self-explanatory, and can be adapted to your needs. The date should respect the format provided. When using `create_post` as shown earlier, many fields will have been filled for you.
+Fields are mostly self-explanatory, and can be adapted to your needs.
+The date should respect the format provided. When using `create_post` as
+shown earlier, many fields will have been filled for you.
 
 ### Referencing packages
 
-You can load packages or use functions via the typical methods `library(tidyverse)`, `require(magrittr)`, `dplyr::mutate()` and folks can run `learn::get_and_update_dependencies()` file to get all packages mentioned in the `content/posts` directory.
+You can load packages or use functions via the typical methods
+`library("tidyverse")`, `require("magrittr")`, `dplyr::mutate()` and
+folks can run `learn::get_and_update_dependencies()` file to get all
+packages mentioned in the `content/posts` directory.
 
-This means you do not need to have mandatory install statements - you can make these `eval=FALSE`.
-
-NB. The `automagic` package used to get dependencies currently does not like `library("tidyverse")` so remove those speechmarks when writing your post!
+This means you do not need to have mandatory install statements - you
+can make these `eval=FALSE`.
 
 ### Storing images
 
-The **image** will be the image associated with the document on the website. We try using natural, high-resolution, evocative images having a link, if only figurative, with the topic covered. These images are stored in `static/img/highres/`. Do not forget to add and push this file as well, as it will be required for your post to be successfully integrated. The path to the file provided in the header assumes `static/` as root folder (see example above), so that the right path will look like: `img/highres/your-image.jpg`.
+The **image** will be the image associated with the document on the
+website. We try using natural, high-resolution, evocative images having
+a link, if only figurative, with the topic covered. These images are
+stored in `static/img/highres/`. Do not forget to add and push this file
+as well, as it will be required for your post to be successfully
+integrated. The path to the file provided in the header assumes
+`static/` as root folder (see example above), so that the right path
+will look like: `img/highres/your-image.jpg`.
 
 ### Bibliographies
 
-The **`bibliography`** is optional. If provided, it should contain references cited in the document as a `bibtex` file (`.bib`). Do not forget to add and push this file as well, as it will be required for your post to be successfully integrated.
+The **`bibliography`** is optional. If provided, it should contain
+references cited in the document as a `bibtex` file (`.bib`). Do not
+forget to add and push this file as well, as it will be required for
+your post to be successfully integrated.
 
-`create_post` create a .bib by default. If you don't need it, delete it and delete the corresponding YAML field.
+`create_post` create a .bib by default. If you don’t need it, delete it
+and delete the corresponding YAML field.
 
-### HTML widgets (plotly, leaflet...)
+### HTML widgets (plotly, leaflet…)
 
-If your post features an interactive plot or map, please use the `save_and_use_widget` function.
+If your post features an interactive plot or map, please use the
+`save_and_use_widget` function.
 
 ``` r
 map <- leaflet::leaflet()
@@ -122,42 +166,61 @@ learn::save_and_use_widget(map, "map.html")
 ```
 
 <!--html_preserve-->
+
 <iframe src="widgets/map.html" width="100%" height="500px">
+
 </iframe>
+
 <!--/html_preserve-->
+
 ### Be nice
 
-As many files could be generated in one go, please don't use any `rm(list=ls())` types of activities. Make your code play nicely with others -- use specific and useful names, don't mess around with the global environment, and don't force any package unloads.
+As many files could be generated in one go, please don’t use any
+`rm(list=ls())` types of activities. Make your code play nicely with
+others – use specific and useful names, don’t mess around with the
+global environment, and don’t force any package unloads.
 
-Contributing slides <a name="slidedeck-creation"></a>
------------------------------------------------------
+## Contributing slides <a name="slidedeck-creation"></a>
 
-Material for slides is stored in `static/slides`. Currently, two files are needed for a lecture:
+Material for slides is stored in `static/slides`. Currently, two files
+are needed for a lecture:
 
-1.  a `.Rmd` post in `content/post` (see above) to introduce the lecture and link to the slides; for an example, look at [`content/post/lecture-reproducibility.Rmd`](https://github.com/reconhub/learn/blob/master/content/post/lecture-basicvbd-modelling.Rmd).
+1.  a `.Rmd` post in `content/post` (see above) to introduce the lecture
+    and link to the slides; for an example, look at
+    [`content/post/lecture-reproducibility.Rmd`](https://github.com/reconhub/learn/blob/master/content/post/lecture-basicvbd-modelling.Rmd).
 
 2.  the slides themselves, stored in `static/slides`.
 
-For the slides, we recommended using `.Rmd` there again, and rendering them before committing them. If your slides use images, store them in `static/img/slides`. You will be able to refer to them using `../../img/slides/your-image.jpg`. For an example of `rmarkdown+ioslides` slides, look at [`static/slides/intro_reproducibility_Rmd/intro_reproducibility.Rmd`](https://github.com/reconhub/learn/blob/master/static/slides/reproducibility/reproducibility.Rmd).
+For the slides, we recommended using `.Rmd` there again, and rendering
+them before committing them. If your slides use images, store them in
+`static/img/slides`. You will be able to refer to them using
+`../../img/slides/your-image.jpg`. For an example of
+`rmarkdown+ioslides` slides, look at
+[`static/slides/intro_reproducibility_Rmd/intro_reproducibility.Rmd`](https://github.com/reconhub/learn/blob/master/static/slides/reproducibility/reproducibility.Rmd).
 
-Visualising the changes
------------------------
+## Visualising the changes
 
-Once a pull request (PR) has been made against <https://github.com/reconhub/learn/>, a new version of the website matching the PR will be deployed online at a new URL with the form `https://deploy-preview-xyz--reconlearn-test.netlify.com/` where `xyz` is the number of the pull request. For instance, PR 26 will be deployed at: <https://deploy-preview-26--reconlearn-test.netlify.com/> .
+Once a pull request (PR) has been made against
+<https://github.com/reconhub/learn/>, a new version of the website
+matching the PR will be deployed online at a new URL with the form
+`https://deploy-preview-xyz--reconlearn-test.netlify.com/` where `xyz`
+is the number of the pull request. For instance, PR 26 will be deployed
+at: <https://deploy-preview-26--reconlearn-test.netlify.com/> .
 
-About this document
-===================
+# About this document
 
-Contributors
-------------
+## Contributors
 
--   Locke Data: initial version
+  - Locke Data: initial version
 
--   Thibaut Jombart: precisions on cloning and PR deploys
+  - Thibaut Jombart: precisions on cloning and PR deploys
 
-Contributions are welcome via [pull requests](https://github.com/reconhub/learn/pulls).
+  - Zhian N. Kamvar: Clarificaton of rendering and forking
 
-Legal stuff
------------
+Contributions are welcome via [pull
+requests](https://github.com/reconhub/learn/pulls).
 
-**License**: [CC-BY](https://creativecommons.org/licenses/by/3.0/) **Copyright**: Locke Data, 2018
+## Legal stuff
+
+**License**: [CC-BY](https://creativecommons.org/licenses/by/3.0/)
+**Copyright**: Locke Data, 2018

--- a/man/render_new_rmds_to_md.Rd
+++ b/man/render_new_rmds_to_md.Rd
@@ -13,6 +13,8 @@ render_new_rmds_to_md(dir = "content/post", build = "new", tol = 1,
 \item{build}{Selection criteria for which Rmds to convert to md, options are c("all", "old and new", "old", "new")}
 
 \item{dry_run}{When `TRUE`, targets are printed, but not rendered. Defaults to `FALSE`.}
+
+\item{when}{`build = "old"` or `build = "old and new"`, this number will avoid re-building md files that are fewer than `tol` seconds old.}
 }
 \value{
 Used for pure side effect. If `dry_run = TRUE`, then the list of targets to be rendered will be printed.

--- a/man/render_new_rmds_to_md.Rd
+++ b/man/render_new_rmds_to_md.Rd
@@ -4,15 +4,18 @@
 \alias{render_new_rmds_to_md}
 \title{Prep Hugo pages by converting Rmds to Md's}
 \usage{
-render_new_rmds_to_md(dir = "content/post", build = "new")
+render_new_rmds_to_md(dir = "content/post", build = "new", tol = 1,
+  dry_run = FALSE)
 }
 \arguments{
 \item{dir}{Directory to search for new Rmds in. Defaults to the blog post location of Hugo.}
 
 \item{build}{Selection criteria for which Rmds to convert to md, options are c("all", "old and new", "old", "new")}
+
+\item{dry_run}{When `TRUE`, targets are printed, but not rendered. Defaults to `FALSE`.}
 }
 \value{
-Used for pure side effect
+Used for pure side effect. If `dry_run = TRUE`, then the list of targets to be rendered will be printed.
 }
 \description{
 Assumes anything without a corresponding markdown file


### PR DESCRIPTION
I've updated the package so that it's a bit easier to use:

The main thing it does differently is now place all artifacts into the `static/` directory as opposed to the `content/` directory. This will address many of the issues brought up in #46 

### Imported packages:

 - Added *rprojroot*
 - Replaced *automagic* with *checkpoint* for package detection since *automagic* couldn't handle quotes in `library()` calls (unforgivable in my opinion).

### New functionalities

 - `render_new_rmds_to_md()` now has a `dry_run` parameter which will simply print the Rmarkdown documents which need rendering
 - `render_new_rmds_to_md()` now has a `tol` parameter, letting you specify the number of seconds difference two files can have and not be re-built.